### PR TITLE
Fix CRedis client _prepare_command().

### DIFF
--- a/components/yii-resque/lib/Credis/Client.php
+++ b/components/yii-resque/lib/Credis/Client.php
@@ -768,6 +768,10 @@ class Credis_Client {
 
     private static function _map($arg)
     {
+         if (is_array($arg)) {
+            $arg = implode(' ', $arg);
+        }
+        
         return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
     }
 


### PR DESCRIPTION
I found a bug like this: https://github.com/kamisama/Cake-Resque/issues/30

To fix this you can look at https://github.com/kamisama/php-resque-ex/blob/master/lib/Redisent/Redisent.php#L147